### PR TITLE
Add "setup webhooks" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ To be notified of events via webhooks, you must
 [register
 the webhook via the JIRA administration console](https://developer.atlassian.com/jiradev/jira-apis/webhooks#Webhooks-jiraadmin).
 
+If the bot's JIRA account is an administrator, the bot can do this itself when
+you tell it to `setup webhooks`.
+
+If the bot is not an administrator, you must setup up webhooks manually.
 The URL should be `<PUBLIC_ADDRESS>/jira/receive`, where `<PUBLIC_ADDRESS>` is
 the same URL as specified above. Be sure to select the notifications that you
 want to receive in the administration console.

--- a/README.md
+++ b/README.md
@@ -35,8 +35,12 @@ The URL should be `<PUBLIC_ADDRESS>/jira/receive`, where `<PUBLIC_ADDRESS>` is
 the same URL as specified above. Be sure to select the notifications that you
 want to receive in the administration console.
 
-Additionally, you need to specify which room to post the webhook notifications
-to. This is done using the `JIRA_WEBHOOK_ROOM` environment variable and should
+Once the webhooks are setup in JIRA, you can use the `watch` command with the bot
+to receive notifications of updates to the watched issues. The updates will be
+posted to whichever room the command was given in.
+
+Additionally, you can specify a room to receive all webhook notifications.
+This is done using the `JIRA_WEBHOOK_ROOM` environment variable and should
 be the ID of the room you want notifications posted to. A script to list rooms
 and their IDs (`yarn list-rooms`) has been included to make finding the desired
 room ID easier.

--- a/src/attachHandlers.js
+++ b/src/attachHandlers.js
@@ -45,5 +45,7 @@ export default (controller, handlers) => {
     '^stop watching(?: ticket)? (.*)'
   ], 'direct_mention,direct_message', handlers.watch.handleUnwatchTicket)
 
+  controller.hears([/^setup$/, /^setup webhooks$/], 'direct_mention,direct_message', handlers.handleSetup)
+
   controller.hears([/^$/, 'help'], 'direct_mention,direct_message', handlers.displayHelp)
 }

--- a/src/handlers/index.js
+++ b/src/handlers/index.js
@@ -1,6 +1,7 @@
 import issues from './issues'
 import watch from './watch'
 import webhooks from './webhooks'
+import jira from '../jira'
 
 const displayHelp = (bot, message) => bot.reply(message, `
   Here are some of the things I can do:
@@ -25,9 +26,48 @@ const displayHelp = (bot, message) => bot.reply(message, `
 export const handleJoin = (bot, message) =>
   bot.reply(message, 'This trusty JIRA bot is here to help.')
 
+export const handleSetup = async (bot, message) => {
+  const isAdmin = await jira.isAdmin()
+  if (!isAdmin) {
+    bot.reply(message, `
+      It appears I don't have adminstrator priveleges on JIRA. A site \
+      administrator will need to head over to \
+      ${process.env.JIRA_HOST}/plugins/servlet/webhooks and enter \
+      \`${process.env.PUBLIC_ADDRESS}jira/receive\` for the webhook URL. I recommend \
+      registering for at least the "Issue" events for your requested project.`)
+  } else {
+    setupWebhooks(bot, message)
+  }
+}
+
+export const setupWebhooks = async (bot, message) => {
+  const webhookName = 'Cisco Spark JIRA Webhook'
+  try {
+    const existingWebhook = await jira.findWebhook(webhookName)
+    if (existingWebhook) {
+      await jira.updateWebhook(existingWebhook)
+    } else {
+      await jira.createWebhook(webhookName)
+    }
+    const action = existingWebhook ? 'updated' : 'set up'
+    bot.reply(message, `
+      I've ${action} the "${webhookName}" webhook for you on \
+      ${process.env.JIRA_HOST}. To receive updates on a particular ticket, \
+      you can tell me which issue to watch: \`start watching TEST-1\`, for example.`)
+  } catch (error) {
+    console.log('ERROR: Got error when attempting to setup webhook.', error.message)
+    bot.reply(message, `
+      Woops! Looks like something went wrong when I tried to setup the webhook. \
+      A JIRA adminstrator will need to head over to \
+      ${process.env.JIRA_HOST}/plugins/servlet/webhooks and enter \
+      \`${process.env.PUBLIC_ADDRESS}jira/receive\` for the webhook URL.`)
+  }
+}
+
 export default {
   displayHelp,
   handleJoin,
+  handleSetup,
   issues,
   watch,
   webhooks

--- a/src/handlers/index.js
+++ b/src/handlers/index.js
@@ -28,15 +28,19 @@ const displayHelp = (bot, message) => bot.reply(message, `
 export const handleJoin = (bot, message) =>
   bot.reply(message, 'This trusty JIRA bot is here to help.')
 
+const setupInstructions = `
+  A JIRA administrator will need to head over to \
+  ${process.env.JIRA_HOST}/plugins/servlet/webhooks and enter \
+  \`${process.env.PUBLIC_ADDRESS}jira/receive\` for the webhook URL. \
+`
+
 export const handleSetup = async (bot, message) => {
   const isAdmin = await jira.isAdmin()
   if (!isAdmin) {
     bot.reply(message, `
-      It appears I don't have adminstrator priveleges on JIRA. A site \
-      administrator will need to head over to \
-      ${process.env.JIRA_HOST}/plugins/servlet/webhooks and enter \
-      \`${process.env.PUBLIC_ADDRESS}jira/receive\` for the webhook URL. I recommend \
-      registering for at least the "Issue" events for your requested project.`)
+      It appears I don't have adminstrator priveleges on JIRA. \
+      ${setupInstructions} I recommend registering for at least the "Issue" \
+      events for your requested project.`)
   } else {
     setupWebhooks(bot, message)
   }
@@ -60,9 +64,7 @@ export const setupWebhooks = async (bot, message) => {
     console.log('ERROR: Got error when attempting to setup webhook.', error.message)
     bot.reply(message, `
       Woops! Looks like something went wrong when I tried to setup the webhook. \
-      A JIRA adminstrator will need to head over to \
-      ${process.env.JIRA_HOST}/plugins/servlet/webhooks and enter \
-      \`${process.env.PUBLIC_ADDRESS}jira/receive\` for the webhook URL.`)
+      ${setupInstructions}`)
   }
 }
 

--- a/src/handlers/index.js
+++ b/src/handlers/index.js
@@ -20,6 +20,8 @@ const displayHelp = (bot, message) => bot.reply(message, `
     \`start watching TEST-12\`. To stop receiving notifications, you can tell \
     me to stop watching a ticket: \`stop watching TEST-12\`. To see a list of \
     tickets I'm watching you can use: \`list watched tickets\`.
+  - **setup webhooks** — In order to watch tickets, webhooks must be setup. I \
+    can assist with setting up webhooks if you use the \`setup webhooks\` command.
   - **help** — display this message
 `)
 


### PR DESCRIPTION
If the bot is an administrator, we can automatically set up webhooks. Otherwise, we can print some useful information on how to manually set them up.