### PR TITLE
Add support to limit org/email domains to interact with the bot

### DIFF
--- a/.env
+++ b/.env
@@ -4,6 +4,10 @@
 # SPARK_SECRET=super-secret
 # PORT=3000
 # REDIS_URL=http://localhost:6379
+# LIMIT_TO_ORG=our_org_id
+# LIMIT_TO_DOMAIN=example.com
+# Or, if limiting to multiple domains
+# LIMIT_TO_DOMAIN="example.com example2.com"
 
 # JIRA configuration
 # JIRA_HOST=https://YOUR_SUBDOMAIN.atlassian.net

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ are expected to exist in the environment (or `.env` or `.env.local` files):
 * `ACCESS_TOKEN` - the bot's access token from Cisco Spark
 * `SPARK_SECRET` - [secret for validating the origin of
   webhooks](https://developer.ciscospark.com/webhooks-explained.html#auth)
+* `LIMIT_TO_ORG` - (optional) ID of the organization that the bot should reply
+  to. Users not in this org sending messages to the bot will receive no reply.
+* `LIMIT_TO_DOMAIN` - (optional) Email domain(s) of users that can message the
+  bot. Users whose email is not in one of these domains are ignored by the bot.
+  If multiple domains are supported, they should be specified as a space-separated
+  list of domains (`"example.com example2.com"`).
 
 ## JIRA Configuration
 

--- a/app.json
+++ b/app.json
@@ -16,6 +16,14 @@
       "description": "A secret for validating that incoming webhooks originate from Cisco Spark.",
       "required": true
     },
+    "LIMIT_TO_ORG": {
+      "description": "ID of the organization that the bot should reply to. Users not in this org sending messages to the bot will receive no reply.",
+      "required": false
+    },
+    "LIMIT_TO_DOMAIN": {
+      "description": "Email domain(s) of users that can message the bot. Users whose email is not in one of these domains are ignored by the bot.  If multiple domains are supported, they should be specified as a space-separated list of domains.",
+      "required": false
+    },
     "PORT": {
       "description": "Port that the bot will run on",
       "value": "3000",

--- a/src/controller.js
+++ b/src/controller.js
@@ -25,7 +25,9 @@ const controller = sparkbot({
   storage: promisify(redisStorage({
     url: process.env.REDIS_URL,
     methods: ['tickets']
-  }), promisifyHack)
+  }), promisifyHack),
+  limit_to_org: process.env.LIMIT_TO_ORG || null,
+  limit_to_domain: (process.env.LIMIT_TO_DOMAIN && process.env.LIMIT_TO_DOMAIN.split(' ')) || null
 })
 
 export default controller


### PR DESCRIPTION
Take advantage of `limit_to_org` and `limit_to_domain` options when creating the spark bot.