### PR TITLE
Fix JIRA webhook URL 

### DIFF
--- a/src/handlers/index.js
+++ b/src/handlers/index.js
@@ -2,6 +2,7 @@ import issues from './issues'
 import watch from './watch'
 import webhooks from './webhooks'
 import jira from '../jira'
+import jiraWebhookUrl from '../utils/jiraWebhookUrl'
 
 const displayHelp = (bot, message) => bot.reply(message, `
   Here are some of the things I can do:
@@ -31,7 +32,7 @@ export const handleJoin = (bot, message) =>
 const setupInstructions = `
   A JIRA administrator will need to head over to \
   ${process.env.JIRA_HOST}/plugins/servlet/webhooks and enter \
-  \`${process.env.PUBLIC_ADDRESS}jira/receive\` for the webhook URL. \
+  \`${jiraWebhookUrl}\` for the webhook URL. \
 `
 
 export const handleSetup = async (bot, message) => {

--- a/src/jira.js
+++ b/src/jira.js
@@ -1,4 +1,5 @@
 import request from 'request-promise-native'
+import jiraWebhookUrl from './utils/jiraWebhookUrl'
 
 export const api = request.defaults({
   auth: {
@@ -79,8 +80,7 @@ export const isAdmin = async () => {
 
 export const findWebhook = async () => {
   const webhooks = await webhookApi.get('/webhook')
-  const url = `${process.env.PUBLIC_ADDRESS}jira/receive`
-  return webhooks.find(webhook => webhook.url === url)
+  return webhooks.find(webhook => webhook.url === jiraWebhookUrl)
 }
 
 const webhookDetails = (name) => ({
@@ -92,7 +92,7 @@ const webhookDetails = (name) => ({
     'jira:issue_deleted'
   ],
   excludeBody: false,
-  url: `${process.env.PUBLIC_ADDRESS}jira/receive`
+  url: jiraWebhookUrl
 })
 
 export const createWebhook = async (webhookName) => {

--- a/src/utils/jiraWebhookUrl.js
+++ b/src/utils/jiraWebhookUrl.js
@@ -1,0 +1,4 @@
+const publicUrl = process.env.PUBLIC_ADDRESS || ''
+const baseUrl = publicUrl.slice(-1) === '/' ? publicUrl : `${publicUrl}/`
+
+export default `${baseUrl}jira/receive`


### PR DESCRIPTION
Fix issue with JIRA webhook URL when public address does not have trailing slash