### PR TITLE
Handle create issue command with unknown issue type

### DIFF
--- a/src/attachHandlers.js
+++ b/src/attachHandlers.js
@@ -18,7 +18,7 @@ export default (controller, handlers) => {
   controller.hears(['list (my )?open issues'], 'direct_mention,direct_message', handlers.issues.listMyIssues)
 
   controller.hears([
-    `create (new )?(.*?) (task|story|bug) [${quotes}]?([^${quotes}]*)[${quotes}]?`
+    `create (new )?(.*?) (.*?) [${quotes}]?([^${quotes}]*)[${quotes}]?`
   ], 'direct_mention,direct_message', handlers.issues.createIssue)
 
   controller.hears([

--- a/src/jira.js
+++ b/src/jira.js
@@ -67,6 +67,11 @@ export const getIssue = async (issueKey) => {
   return await api.get(`/issue/${issueKey}`)
 }
 
+export const getIssueTypes = async () => {
+  const allTypes = await api.get('/issuetype')
+  return allTypes.filter(type => (!type.subtask && type.name !== 'Epic'))
+}
+
 export const commentOnIssue = async (issueKey, body) => {
   return await api.post(`/issue/${issueKey}/comment`, {
     body: { body }
@@ -125,6 +130,7 @@ export default {
   findWebhook,
   getIssue,
   getIssues,
+  getIssueTypes,
   isAdmin,
   linkToIssue,
   updateWebhook

--- a/test/fixtures/issue_types.json
+++ b/test/fixtures/issue_types.json
@@ -1,0 +1,28 @@
+[
+    {
+        "avatarId": 10303,
+        "description": "jira.translation.issuetype.bug.name.desc",
+        "iconUrl": "https://pw-test.atlassian.net/secure/viewavatar?size=xsmall&avatarId=10303&avatarType=issuetype",
+        "id": "10103",
+        "name": "Bug",
+        "self": "https://pw-test.atlassian.net/rest/api/2/issuetype/10103",
+        "subtask": false
+    },
+    {
+        "description": "A user story. Created by JIRA Software - do not edit or delete.",
+        "iconUrl": "https://pw-test.atlassian.net/images/icons/issuetypes/story.svg",
+        "id": "10100",
+        "name": "Story",
+        "self": "https://pw-test.atlassian.net/rest/api/2/issuetype/10100",
+        "subtask": false
+    },
+    {
+        "avatarId": 10318,
+        "description": "A task that needs to be done.",
+        "iconUrl": "https://pw-test.atlassian.net/secure/viewavatar?size=xsmall&avatarId=10318&avatarType=issuetype",
+        "id": "10101",
+        "name": "Task",
+        "self": "https://pw-test.atlassian.net/rest/api/2/issuetype/10101",
+        "subtask": false
+    }
+]


### PR DESCRIPTION
When the issue type is unknown, the API returns an error with the `issuetype` key. In that case, fetch a list of non-subtask types and display to the user the valid types.

Also, creating epics requires some other special info when creating the ticket, so specify that we can't create epics yet.